### PR TITLE
improve check if the user has access via groups

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -327,24 +327,11 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
     // check if current user has full access to the organization (either directly or via any group)
     let has_full_access_via_group =
         CONFIG.org_groups_enabled() && GroupUser::has_full_access_by_member(org_id, &user_org.uuid, &mut conn).await;
-    let has_full_access = user_org.access_all || has_full_access_via_group;
+    let has_full_access_to_org = user_org.access_all || has_full_access_via_group;
 
     for col in Collection::find_by_organization(org_id, &mut conn).await {
-        // get the group details for the given collection
-        let groups: Vec<Value> = if CONFIG.org_groups_enabled() {
-            CollectionGroup::find_by_collection(&col.uuid, &mut conn)
-                .await
-                .iter()
-                .map(|collection_group| {
-                    SelectionReadOnly::to_collection_group_details_read_only(collection_group).to_json()
-                })
-                .collect()
-        } else {
-            Vec::with_capacity(0)
-        };
-
         // assigned indicates whether the current user has access to the given collection
-        let mut assigned = has_full_access;
+        let mut assigned = has_full_access_to_org;
 
         // get the users assigned directly to the given collection
         let users: Vec<Value> = coll_users
@@ -363,6 +350,19 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
         if !assigned && CONFIG.org_groups_enabled() {
             assigned = GroupUser::has_access_to_collection_by_member(&col.uuid, &user_org.uuid, &mut conn).await;
         }
+
+        // get the group details for the given collection
+        let groups: Vec<Value> = if CONFIG.org_groups_enabled() {
+            CollectionGroup::find_by_collection(&col.uuid, &mut conn)
+                .await
+                .iter()
+                .map(|collection_group| {
+                    SelectionReadOnly::to_collection_group_details_read_only(collection_group).to_json()
+                })
+                .collect()
+        } else {
+            Vec::with_capacity(0)
+        };
 
         let mut json_object = col.to_json();
         json_object["Assigned"] = json!(assigned);

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -321,13 +321,16 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
         None => err!("User is not part of organization"),
     };
 
+    // get all collection memberships for the current organization
     let coll_users = CollectionUser::find_by_organization(org_id, &mut conn).await;
 
+    // check if current user has full access to the organization (either directly or via any group)
     let has_full_access_via_group =
         CONFIG.org_groups_enabled() && GroupUser::has_full_access_by_member(org_id, &user_org.uuid, &mut conn).await;
     let has_full_access = user_org.access_all || has_full_access_via_group;
 
     for col in Collection::find_by_organization(org_id, &mut conn).await {
+        // get the group details for the given collection
         let groups: Vec<Value> = if CONFIG.org_groups_enabled() {
             CollectionGroup::find_by_collection(&col.uuid, &mut conn)
                 .await
@@ -337,18 +340,18 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
                 })
                 .collect()
         } else {
-            // The Bitwarden clients seem to call this API regardless of whether groups are enabled,
-            // so just act as if there are no groups.
             Vec::with_capacity(0)
         };
 
+        // assigned indicates whether the current user has access to the given collection
         let mut assigned = has_full_access;
+
+        // get the users assigned directly to the given collection
         let users: Vec<Value> = coll_users
             .iter()
             .filter(|collection_user| collection_user.collection_uuid == col.uuid)
             .map(|collection_user| {
-                // Remember `user_uuid` is swapped here with the `user_org.uuid` with a join during the `CollectionUser::find_by_organization` call.
-                // We check here if the current user is assigned to this collection or not.
+                // check if the current user is assigned to this collection directly
                 if collection_user.user_uuid == user_org.uuid {
                     assigned = true;
                 }

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -322,14 +322,10 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
     };
 
     let coll_users = CollectionUser::find_by_organization(org_id, &mut conn).await;
-    // uuids of users in groups having access to all collections
-    let has_full_access_via_group = if CONFIG.org_groups_enabled() {
-        GroupUser::get_members_of_full_access_groups(org_id, &mut conn).await
-    } else {
-        vec![]
-    };
 
-    let has_full_access = user_org.access_all || has_full_access_via_group.contains(&user_org.uuid);
+    let has_full_access_via_group =
+        CONFIG.org_groups_enabled() && GroupUser::has_full_access_by_member(org_id, &user_org.uuid, &mut conn).await;
+    let has_full_access = user_org.access_all || has_full_access_via_group;
 
     for col in Collection::find_by_organization(org_id, &mut conn).await {
         let groups: Vec<Value> = if CONFIG.org_groups_enabled() {
@@ -360,12 +356,10 @@ async fn get_org_collections_details(org_id: &str, headers: ManagerHeadersLoose,
             })
             .collect();
 
-        // if the current user is not assigned and groups are enabled,
-        // check if they have access to the given collection via a group
-        if !assigned && CONFIG.org_groups_enabled()
-        {
-            assigned = GroupUser::get_group_members_for_collection(&col.uuid, &mut conn).await.contains(&user_org.uuid);
-        }     
+        // check if the current user has access to the given collection via a group
+        if !assigned && CONFIG.org_groups_enabled() {
+            assigned = GroupUser::has_access_to_collection_by_member(&col.uuid, &user_org.uuid, &mut conn).await;
+        }
 
         let mut json_object = col.to_json();
         json_object["Assigned"] = json!(assigned);


### PR DESCRIPTION
instead of returning the two lists of member ids and later checking if they contain the uuid of the current user, we really only care if the current user has full access via a group or if they have access to a given collection via a group

also i've refactored the code (and rewritten the comments) a bit to hopefully improve the legibility a bit